### PR TITLE
Add executor control node

### DIFF
--- a/bt_ros/CMakeLists.txt
+++ b/bt_ros/CMakeLists.txt
@@ -38,6 +38,7 @@ include_directories(
 
 add_library(${PROJECT_NAME}
   src/executor_bt.cpp
+  src/controls/executor_node.cpp
 )
 target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${Boost_LIBRARIES})
 
@@ -100,5 +101,13 @@ add_rostest_gtest(subscriber_test
   test/subscriber_test.cpp
 )
 target_link_libraries(subscriber_test
+  ${PROJECT_NAME}
+)
+
+add_rostest_gtest(executor_test
+  test/executor.test
+  test/executor_test.cpp
+)
+target_link_libraries(executor_test
   ${PROJECT_NAME}
 )

--- a/bt_ros/include/bt_ros/controls/executor_node.h
+++ b/bt_ros/include/bt_ros/controls/executor_node.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "behaviortree_cpp_v3/control_node.h"
+
+namespace BT
+{
+/**
+ * @brief The ExecutorNode is used to tick children in an ordered sequence.
+ * It will execute all children in order, regardless of their status.
+ *
+ * It returns success if number of children that returns success is above THRESHOLD_SUCCESS
+ * Otherwise, it returns failure.
+ */
+class ExecutorNode : public ControlNode
+{
+public:
+  ExecutorNode(const std::string& name, unsigned success_threshold);
+  ExecutorNode(const std::string& name, const NodeConfiguration& config);
+
+  virtual ~ExecutorNode() override = default;
+
+  static PortsList providedPorts()
+  {
+    return { InputPort<unsigned>(THRESHOLD_SUCCESS, "number of children which need to succeed to trigger a SUCCESS") };
+  }
+
+  virtual void halt() override;
+
+private:
+  size_t current_child_idx_;
+  unsigned int success_threshold_;
+  bool read_parameter_from_ports_;
+  size_t success_childred_num_;
+  size_t failure_childred_num_;
+
+  virtual BT::NodeStatus tick() override;
+
+  static constexpr auto THRESHOLD_SUCCESS = "success_threshold";
+};
+
+}  // namespace BT

--- a/bt_ros/src/controls/executor_node.cpp
+++ b/bt_ros/src/controls/executor_node.cpp
@@ -1,0 +1,88 @@
+#include "bt_ros/controls/executor_node.h"
+#include "behaviortree_cpp_v3/action_node.h"
+
+namespace BT
+{
+
+ExecutorNode::ExecutorNode(const std::string& name, unsigned success_threshold)
+  : ControlNode::ControlNode(name, {})
+  , current_child_idx_(0)
+  , success_threshold_(success_threshold)
+  , read_parameter_from_ports_(false)
+  , success_childred_num_(0)
+  , failure_childred_num_(0)
+{
+  setRegistrationID("Executor");
+}
+
+ExecutorNode::ExecutorNode(const std::string& name, const NodeConfiguration& config)
+  : ControlNode::ControlNode(name, config)
+  , current_child_idx_(0)
+  , success_threshold_(1)
+  , read_parameter_from_ports_(true)
+  , success_childred_num_(0)
+  , failure_childred_num_(0)
+{
+}
+
+void ExecutorNode::halt()
+{
+  current_child_idx_ = 0;
+  success_childred_num_ = 0;
+  failure_childred_num_ = 0;
+  ControlNode::halt();
+}
+
+NodeStatus ExecutorNode::tick()
+{
+  if (read_parameter_from_ports_)
+  {
+    if (!getInput(THRESHOLD_SUCCESS, success_threshold_))
+    {
+      throw RuntimeError("Missing parameter [", THRESHOLD_SUCCESS, "] in ExecutorNode");
+    }
+  }
+
+  const size_t children_count = children_nodes_.size();
+
+  setStatus(NodeStatus::RUNNING);
+
+  while (current_child_idx_ < children_count)
+  {
+    TreeNode* current_child_node = children_nodes_[current_child_idx_];
+    const NodeStatus child_status = current_child_node->executeTick();
+
+    switch (child_status)
+    {
+      case NodeStatus::RUNNING:
+      {
+        return NodeStatus::RUNNING;
+      }
+      case NodeStatus::FAILURE:
+      {
+        current_child_idx_++;
+        failure_childred_num_++;
+        break;
+      }
+      case NodeStatus::SUCCESS:
+      {
+        current_child_idx_++;
+        success_childred_num_++;
+        break;
+      }
+      case NodeStatus::IDLE:
+      {
+        throw LogicError("A child node must never return IDLE");
+      }
+    }
+  }
+
+  haltChildren();
+  auto result = (success_childred_num_ >= success_threshold_) ? NodeStatus::SUCCESS : NodeStatus::FAILURE;
+  current_child_idx_ = 0;
+  success_childred_num_ = 0;
+  failure_childred_num_ = 0;
+  return result;
+}
+
+}  // namespace BT

--- a/bt_ros/test/executor.test
+++ b/bt_ros/test/executor.test
@@ -1,0 +1,5 @@
+<launch>
+
+  <test test-name="executor_test" pkg="bt_ros" type="executor_test" time-limit="20.0" />
+
+</launch>

--- a/bt_ros/test/executor_test.cpp
+++ b/bt_ros/test/executor_test.cpp
@@ -1,0 +1,213 @@
+#include "bt_ros/controls/executor_node.h"
+#include <behaviortree_cpp_v3/bt_factory.h>
+
+#include <gtest/gtest.h>
+#include <ros/ros.h>
+
+namespace bt_ros::test
+{
+
+class StatefulActionTest : public BT::StatefulActionNode
+{
+public:
+  StatefulActionTest(const std::string& name, const BT::NodeConfiguration& config) : StatefulActionNode(name, config)
+  {
+    expected_result = BT::NodeStatus::RUNNING;
+  }
+
+  BT::NodeStatus onStart() override
+  {
+    on_start_count++;
+    return expected_result;
+  }
+  BT::NodeStatus onRunning() override
+  {
+    on_running_count++;
+    return expected_result;
+  }
+  inline void onHalted() override
+  {
+    on_halted_count++;
+  }
+
+  int on_start_count = 0;
+  int on_running_count = 0;
+  int on_halted_count = 0;
+  BT::NodeStatus expected_result;
+};
+
+class ExecutorTest : public ::testing::Test
+{
+};
+
+TEST_F(ExecutorTest, success)
+{
+  StatefulActionTest stateful("stateful", {});
+  std::shared_ptr<BT::ExecutorNode> executor = std::make_shared<BT::ExecutorNode>("executor", 1);
+  executor->addChild(&stateful);
+
+  auto status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+
+  stateful.expected_result = BT::NodeStatus::SUCCESS;
+
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(stateful.on_start_count, 1);
+  EXPECT_EQ(stateful.on_running_count, 1);
+  EXPECT_EQ(stateful.on_halted_count, 0);
+}
+
+TEST_F(ExecutorTest, failure_after_success)
+{
+  StatefulActionTest stateful_1("stateful_1", {});
+  StatefulActionTest stateful_2("stateful_2", {});
+  std::shared_ptr<BT::ExecutorNode> executor = std::make_shared<BT::ExecutorNode>("executor", 1);
+  executor->addChild(&stateful_1);
+  executor->addChild(&stateful_2);
+
+  auto status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+
+  stateful_1.expected_result = BT::NodeStatus::SUCCESS;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+
+  executor->halt();
+  stateful_1.expected_result = BT::NodeStatus::RUNNING;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 2);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+  EXPECT_EQ(stateful_2.on_halted_count, 1);
+
+  stateful_1.expected_result = BT::NodeStatus::FAILURE;
+  stateful_2.expected_result = BT::NodeStatus::FAILURE;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::FAILURE);
+  EXPECT_EQ(stateful_2.on_start_count, 2);
+  EXPECT_EQ(stateful_2.on_running_count, 0);
+}
+
+TEST_F(ExecutorTest, one_success_ok)
+{
+  StatefulActionTest stateful_1("stateful_1", {});
+  StatefulActionTest stateful_2("stateful_2", {});
+  std::shared_ptr<BT::ExecutorNode> executor = std::make_shared<BT::ExecutorNode>("executor", 1);
+  executor->addChild(&stateful_1);
+  executor->addChild(&stateful_2);
+
+  auto status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 0);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 0);
+
+  stateful_1.expected_result = BT::NodeStatus::SUCCESS;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+
+  stateful_2.expected_result = BT::NodeStatus::FAILURE;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+  EXPECT_EQ(stateful_2.on_halted_count, 0);
+}
+
+TEST_F(ExecutorTest, one_success_one_failure)
+{
+  StatefulActionTest stateful_1("stateful_1", {});
+  StatefulActionTest stateful_2("stateful_2", {});
+  std::shared_ptr<BT::ExecutorNode> executor = std::make_shared<BT::ExecutorNode>("executor", 2);
+  executor->addChild(&stateful_1);
+  executor->addChild(&stateful_2);
+
+  auto status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 0);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 0);
+
+  stateful_1.expected_result = BT::NodeStatus::SUCCESS;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+
+  stateful_2.expected_result = BT::NodeStatus::FAILURE;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::FAILURE);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+  EXPECT_EQ(stateful_2.on_halted_count, 0);
+}
+
+TEST_F(ExecutorTest, one_failure_one_success)
+{
+  StatefulActionTest stateful_1("stateful_1", {});
+  StatefulActionTest stateful_2("stateful_2", {});
+  std::shared_ptr<BT::ExecutorNode> executor = std::make_shared<BT::ExecutorNode>("executor", 1);
+  executor->addChild(&stateful_1);
+  executor->addChild(&stateful_2);
+
+  auto status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 0);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 0);
+
+  stateful_1.expected_result = BT::NodeStatus::FAILURE;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::RUNNING);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+
+  stateful_2.expected_result = BT::NodeStatus::SUCCESS;
+  status = executor->executeTick();
+  EXPECT_EQ(status, BT::NodeStatus::SUCCESS);
+  EXPECT_EQ(stateful_1.on_start_count, 1);
+  EXPECT_EQ(stateful_1.on_running_count, 1);
+  EXPECT_EQ(stateful_1.on_halted_count, 0);
+  EXPECT_EQ(stateful_2.on_start_count, 1);
+  EXPECT_EQ(stateful_2.on_halted_count, 0);
+}
+
+}  // namespace bt_ros::test
+
+int main(int argc, char** argv)
+{
+  ros::init(argc, argv, "executor_test");
+
+  // enable debug logging for tests
+  if (ros::console::set_logger_level(ROSCONSOLE_DEFAULT_NAME, ros::console::levels::Debug))
+    ros::console::notifyLoggerLevelsChanged();
+
+  ros::AsyncSpinner spinner(0);
+  spinner.start();
+  testing::InitGoogleTest(&argc, argv);
+  auto result = RUN_ALL_TESTS();
+  spinner.stop();
+  return result;
+}


### PR DESCRIPTION
# Description
The `ExecutorNode` is used to tick children as in a SequenceNode.
However, it will execute all children in order, regardless of their status.

It returns success if number of children that returns success is above `THRESHOLD_SUCCESS` parameter
Otherwise, it returns failure.